### PR TITLE
Default hindent-extra-args to nil

### DIFF
--- a/lisp/init-haskell.el
+++ b/lisp/init-haskell.el
@@ -30,7 +30,8 @@
 (add-hook 'haskell-mode-hook 'haskell-auto-insert-module-template)
 
 (when (maybe-require-package 'hindent)
-  (add-hook 'haskell-mode-hook 'hindent-mode))
+  (add-hook 'haskell-mode-hook 'hindent-mode)
+  (setq-default hindent-extra-args nil))
 
 (after-load 'haskell-mode
   (define-key haskell-mode-map (kbd "C-c h") 'hoogle)


### PR DESCRIPTION
Works around an upstream bug for which I've submitted a patch.